### PR TITLE
Herokuにデプロイ

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,1 @@
+FRONTEND_ORIGIN = https://reactrails.herokuapp.com/

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@
 /config/master.key
 
 .env
+/public

--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,8 @@ gem 'bootsnap', '>= 1.4.4', require: false
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 gem 'rack-cors'
 
+gem 'dotenv-rails'
+
 group :development, :test do
   gem 'sqlite3', '~> 1.4'
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
@@ -33,7 +35,6 @@ group :development do
   gem 'listen', '~> 3.3'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
-  gem 'dotenv-rails'
 end
 
 group :production do

--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,6 @@ ruby '2.6.8'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails', branch: 'main'
 gem 'rails', '~> 6.1.4', '>= 6.1.4.1'
-# Use sqlite3 as the database for Active Record
-gem 'sqlite3', '~> 1.4'
 # Use Puma as the app server
 gem 'puma', '~> 5.0'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
@@ -26,6 +24,7 @@ gem 'bootsnap', '>= 1.4.4', require: false
 gem 'rack-cors'
 
 group :development, :test do
+  gem 'sqlite3', '~> 1.4'
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
 end
@@ -35,6 +34,10 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'dotenv-rails'
+end
+
+group :production do
+  gem 'pg'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.12.4-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.12.4-x86_64-linux)
+      racc (~> 1.4)
     pg (1.2.3)
     puma (5.5.0)
       nio4r (~> 2.0)
@@ -150,6 +152,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap (>= 1.4.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,7 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.12.4-x86_64-darwin)
       racc (~> 1.4)
+    pg (1.2.3)
     puma (5.5.0)
       nio4r (~> 2.0)
     racc (1.5.2)
@@ -155,6 +156,7 @@ DEPENDENCIES
   byebug
   dotenv-rails
   listen (~> 3.3)
+  pg
   puma (~> 5.0)
   rack-cors
   rails (~> 6.1.4, >= 6.1.4.1)

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec rails s

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,0 +1,2 @@
+REACT_APP_API_URL = https://reactrails.herokuapp.com/api/v1
+

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -9,7 +9,7 @@ const App = () => {
   const [inputValue, setInputValue] = useState({ title: '', content: '' });
 
   useEffect(() => {
-    fetch(`${process.env.REACT_APP_DEV_API_URL}/posts`, {
+    fetch(`${process.env.REACT_APP_API_URL}/posts`, {
       method: 'GET'
     })
       .then(res => res.json())
@@ -23,7 +23,7 @@ const App = () => {
   };
 
   const submitPost = () => {
-    fetch(`${process.env.REACT_APP_DEV_API_URL}/posts`, {
+    fetch(`${process.env.REACT_APP_API_URL}/posts`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -43,7 +43,7 @@ const App = () => {
   };
 
   const updatePost = (postId, updateValue) => {
-    fetch(`${process.env.REACT_APP_DEV_API_URL}/posts/${postId}`, {
+    fetch(`${process.env.REACT_APP_API_URL}/posts/${postId}`, {
       method: 'PATCH',
       headers: {
         'Content-Type': 'application/json',
@@ -60,7 +60,7 @@ const App = () => {
   };
 
   const deletePost = postId => {
-    fetch(`${process.env.REACT_APP_DEV_API_URL}/posts/${postId}`, {
+    fetch(`${process.env.REACT_APP_API_URL}/posts/${postId}`, {
       method: 'DELETE'
     })
       .then(() => {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "react_rails",
+  "version": "1.0.0",
+  "description": "This README would normally document whatever steps are necessary to get the application up and running.",
+  "main": "index.js",
+  "directories": {
+    "lib": "lib",
+    "test": "test"
+  },
+  "scripts": {
+    "build": "cd frontend && npm install && npm run build && cd ..",
+    "deploy": "cp -a frontend/build/. public/",
+    "heroku-postbuild": "npm run build && npm run deploy && echo 'Client build!'"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/roaris/react_rails.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/roaris/react_rails/issues"
+  },
+  "homepage": "https://github.com/roaris/react_rails#readme"
+}


### PR DESCRIPTION
### 関連issue
#1 
### やったこと
- https://reactrails.herokuapp.com/ へのデプロイ
  - herokuへのデプロイ時に、reactのビルドファイルをrailsのpublic下に配置するコマンドをpackage.jsonに記述
### 参考
- [Rails+Reactアプリを1つのdynoでデプロイする](https://qiita.com/mayutakino/items/446512b12b84a07d3f4b)
- [Failed to install gems via Bundler.」が出た時の対処法 HEROKU](https://qiita.com/m6mmsf/items/fb8a8672df98bdb59c9c)