### PR TITLE
Herokuでreact-routerが動くように修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,12 @@
 class ApplicationController < ActionController::API
+  include ActionController::MimeResponds
+
+  def fallback_index_html
+    respond_to do |format|
+      format.html { render body: Rails.root.join('public/index.html').read }
+    end
+  end
+
   def current_user
     @current_user ||= User.find(session[:user_id]) if session[:user_id]
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,4 +8,8 @@ Rails.application.routes.draw do
       resources :posts
     end
   end
+
+  get '*path', to: "application#fallback_index_html", constraints: ->(request) do
+    !request.xhr? && request.format.html?
+  end
 end


### PR DESCRIPTION
### 関連するissue
#11 

### やったこと
- `ApplicationController`にpublic/index.htmlを返すメソッドを定義し、routes.rbでそのメソッドを呼び出すように修正

### バグの原因
本番環境では、reactアプリをbuildし、1枚のindex.htmlにして動作させているため、ルーティングが上手く動作していないと考えられる。([参考](https://qiita.com/kataoka029/items/7aac52bc47fc9bb65611))

### 参考
- [react-routerを使ったルーティングをherokuで動かすために必要なこと](https://qiita.com/kataoka029/items/7aac52bc47fc9bb65611)
(ここで書かれているstatic.jsonを追加する方法は上手くいかなかった。原因は不明。)
- [Rails+Reactアプリを1つのdynoでデプロイする](https://qiita.com/mayutakino/items/446512b12b84a07d3f4b)