### PR TITLE
未ログインユーザーが投稿の操作をできないように修正

### DIFF
--- a/app/controllers/api/v1/posts_controller.rb
+++ b/app/controllers/api/v1/posts_controller.rb
@@ -1,6 +1,8 @@
 module Api
   module V1
     class PostsController < ApplicationController
+      before_action :require_login
+
       def index
         posts = Post.all.order(:id)
         render json: posts

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,4 +10,9 @@ class ApplicationController < ActionController::API
   def current_user
     @current_user ||= User.find(session[:user_id]) if session[:user_id]
   end
+
+  def require_login
+    return if current_user
+    render status: 401
+  end
 end

--- a/frontend/src/components/Home.js
+++ b/frontend/src/components/Home.js
@@ -10,7 +10,8 @@ const App = () => {
 
   useEffect(() => {
     fetch(`${process.env.REACT_APP_API_URL}/posts`, {
-      method: 'GET'
+      method: 'GET',
+      credentials: 'include'
     })
       .then(res => res.json())
       .then(setPosts)
@@ -25,6 +26,7 @@ const App = () => {
   const submitPost = () => {
     fetch(`${process.env.REACT_APP_API_URL}/posts`, {
       method: 'POST',
+      credentials: 'include',
       headers: {
         'Content-Type': 'application/json',
       },
@@ -45,6 +47,7 @@ const App = () => {
   const updatePost = (postId, updateValue) => {
     fetch(`${process.env.REACT_APP_API_URL}/posts/${postId}`, {
       method: 'PATCH',
+      credentials: 'include',
       headers: {
         'Content-Type': 'application/json',
       },
@@ -61,7 +64,8 @@ const App = () => {
 
   const deletePost = postId => {
     fetch(`${process.env.REACT_APP_API_URL}/posts/${postId}`, {
-      method: 'DELETE'
+      method: 'DELETE',
+      credentials: 'include'
     })
       .then(() => {
         const newPosts = posts.slice();


### PR DESCRIPTION
### 関連issue
#19 

### やったこと
- ApplicationControllerに`require_login`メソッドを定義 未ログインユーザーに対しては、401を返す
- PostsControllerのbefore_actionに`require_login`メソッドを指定
- Home.js中のfetchについて、`credentials: 'include'`を追加し、cookieを送信するように修正

### 参考
- [【Rails API + SPA】ログイン方法とCSRF対策例](https://qiita.com/k_kind/items/e26f03f4e24551b46b98)
