### PR TITLE
投稿にユーザーIDを持たせる

### DIFF
--- a/app/controllers/api/v1/posts_controller.rb
+++ b/app/controllers/api/v1/posts_controller.rb
@@ -14,7 +14,7 @@ module Api
       end
 
       def create
-        post = Post.new(post_params)
+        post = current_user.posts.build(post_params)
         if post.save
           render json: post
         else

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,4 +1,6 @@
 class Post < ApplicationRecord
+  belongs_to :user
   validates :title, presence: true
   validates :content, presence: true
+  validates :user_id, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  has_many :posts, dependent: :destroy
   validates :name, {presence: true, length: {minimum: 3, maximum: 20}}
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i
   validates :email, {

--- a/db/migrate/20211008191141_user_id_to_posts.rb
+++ b/db/migrate/20211008191141_user_id_to_posts.rb
@@ -1,0 +1,5 @@
+class UserIdToPosts < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :posts, :user, foreign_key: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_28_122511) do
+ActiveRecord::Schema.define(version: 2021_10_08_191141) do
 
   create_table "posts", force: :cascade do |t|
     t.string "title", null: false
     t.string "content", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "user_id", null: false
+    t.index ["user_id"], name: "index_posts_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -28,4 +30,5 @@ ActiveRecord::Schema.define(version: 2021_09_28_122511) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "posts", "users"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,6 +6,12 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
+require 'factory_bot_rails'
+
 (1..5).each do |i|
-  Post.create!(title: "title#{i}", content: "content#{i}")
+  FactoryBot.create(:user)
+end
+
+(1..10).each do |i|
+  FactoryBot.create(:post, user_id: (i-1)/2+1)
 end

--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :post do
+    sequence(:title) { |n| "title#{n}"}
+    sequence(:content) { |n| "content#{n}"}
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :user do
-    sequence(:name) {"test"}
-    sequence(:email) {"test@example.com"}
+    sequence(:name) { |n| "test#{n}"}
+    sequence(:email) { |n| "test#{n}@example.com"}
     sequence(:password) {"password"}
   end
 end

--- a/spec/models/users_spec.rb
+++ b/spec/models/users_spec.rb
@@ -38,8 +38,8 @@ RSpec.describe User, type: :model do
   end
 
   it 'is invalid with a duplicated email address' do
-    user1 = FactoryBot.create(:user)
-    user2 = FactoryBot.build(:user)
+    user1 = FactoryBot.create(:user, email: 'test@example.com')
+    user2 = FactoryBot.build(:user, email: 'test@example.com')
     expect(user2).to be_invalid
   end
 


### PR DESCRIPTION
### 関連issue
#23 

### やったこと
- postsテーブルにuser_idカラムを追加し、外部キー制約をつけた
- Postモデルからbelongs_toのアソシエーションをUserモデルに、Userモデルからhas_manyのアソシエーションをPostモデルに指定 ユーザーが削除されると、そのユーザーの投稿も消えるように、`dependent: :destroy`を指定
- seeds.rbの修正
  - UserモデルのFactoryBotを修正
  - PostモデルのFactoryBotを作成
- UserモデルのFactoryBotを修正したことで、Userモデルのテストが1つfailしたので、テストファイルを修正

### 備考
データベースを初期化しないと、マイグレーションファイルの`null: false`でエラーになるので注意

### 参考
- [Railsの外部キー制約とreference型について](https://qiita.com/ryouzi/items/2682e7e8a86fd2b1ae47)
- [[Ruby] 整数同士の割り算](https://qiita.com/cia_rana/items/525ed5a57a28aaf9d2eb)
- [User/Micropostの関連付け](https://railstutorial.jp/chapters/user_microposts?version=4.2#sec-user_micropost_associations)
