### PR TITLE
/api/v1/postsのテスト

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -63,4 +63,5 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
 
   config.include FactoryBot::Syntax::Methods
+  config.include TestHelper
 end

--- a/spec/requests/posts_spec.rb
+++ b/spec/requests/posts_spec.rb
@@ -1,0 +1,152 @@
+require 'rails_helper'
+
+RSpec.describe '/api/v1/posts', type: :request do
+  let!(:user) { create(:user) }
+
+  describe 'index' do
+    it 'accept an auth user' do
+      create_list(:post, 10)
+      log_in_as(user)
+      get '/api/v1/posts', headers: xhr_header
+      expect(response.status).to eq(200)
+      expect(json(response).length).to eq(10)
+    end
+
+    it 'reject an unauth user' do
+      get '/api/v1/posts', headers: xhr_header
+      expect(response.status).to eq(401)
+    end
+
+    it 'protect from CSRF' do
+      log_in_as(user)
+      get '/api/v1/posts'
+      expect(response.status).to eq(403)
+    end
+  end
+
+  describe 'show' do
+    let!(:post) { create(:post) }
+
+    it 'accept an auth user' do
+      log_in_as(user)
+      get "/api/v1/posts/#{post.id}", headers: xhr_header
+      expect(response.status).to eq(200)
+      expect(json(response)['title']).to eq(post.title)
+      expect(json(response)['content']).to eq(post.content)
+    end
+
+    it 'reject an unauth user' do
+      get "/api/v1/posts/#{post.id}", headers: xhr_header
+      expect(response.status).to eq(401)
+    end
+
+    it 'protect from CSRF' do
+      log_in_as(user)
+      get "/api/v1/posts/#{post.id}"
+      expect(response.status).to eq(403)
+    end
+  end
+
+  describe 'create' do
+    it 'accept a valid post' do
+      log_in_as(user)
+      post_params = { title: 'test_title', content: 'test_content' }
+      expect do
+        post '/api/v1/posts', params: post_params.to_json, headers: xhr_header.merge(json_header)
+      end.to change(Post, :count).by(1)
+      expect(response.status).to eq(201)
+      expect(json(response)['title']).to eq('test_title')
+      expect(json(response)['content']).to eq('test_content')
+    end
+
+    it 'reject a post with an empty title' do
+      log_in_as(user)
+      post_params = { title: '', content: 'test_content' }
+      post '/api/v1/posts', params: post_params.to_json, headers: xhr_header.merge(json_header)
+      expect(response.status).to eq(400)
+    end
+
+    it 'reject a post with an empty content' do
+      log_in_as(user)
+      post_params = { title: 'test_content', content: '' }
+      post '/api/v1/posts', params: post_params.to_json, headers: xhr_header.merge(json_header)
+      expect(response.status).to eq(400)
+    end
+
+    it 'reject an unauth user' do
+      post_params = { title: 'test_title', content: 'test_content' }
+      post '/api/v1/posts', params: post_params.to_json, headers: xhr_header.merge(json_header)
+      expect(response.status).to eq(401)
+    end
+
+    it 'protect from CSRF' do
+      log_in_as(user)
+      post_params = { title: 'test_title', content: 'test_content' }
+      post '/api/v1/posts', params: post_params.to_json, headers: json_header
+      expect(response.status).to eq(403)
+    end
+  end
+
+  describe 'update' do
+    let!(:post) { create(:post) }
+
+    it 'accept a valid update' do
+      log_in_as(user)
+      update_params = { title: 'test_title', content: 'test_content' }
+      patch "/api/v1/posts/#{post.id}", params: update_params.to_json, headers: xhr_header.merge(json_header)
+      expect(response.status).to eq(200)
+      expect(json(response)['title']).to eq('test_title')
+      expect(json(response)['content']).to eq('test_content')
+    end
+
+    it 'reject an update with an empty title' do
+      log_in_as(user)
+      update_params = { title: '', content: 'test_content' }
+      patch "/api/v1/posts/#{post.id}", params: update_params.to_json, headers: xhr_header.merge(json_header)
+      expect(response.status).to eq(400)
+    end
+
+    it 'reject an update with an empty content' do
+      log_in_as(user)
+      update_params = { title: 'test_title', content: '' }
+      patch "/api/v1/posts/#{post.id}", params: update_params.to_json, headers: xhr_header.merge(json_header)
+      expect(response.status).to eq(400)
+    end
+
+    it 'reject an unauth user' do
+      update_params = { title: 'test_title', content: 'test_content' }
+      patch "/api/v1/posts/#{post.id}", params: update_params.to_json, headers: xhr_header.merge(json_header)
+      expect(response.status).to eq(401)
+    end
+
+    it 'protect from CSRF' do
+      log_in_as(user)
+      update_params = { title: 'test_title', content: 'test_content' }
+      patch "/api/v1/posts/#{post.id}", params: update_params.to_json, headers: json_header
+      expect(response.status).to eq(403)
+    end
+  end
+
+  describe 'delete' do
+    let!(:post) { create(:post) }
+
+    it 'accept an auth user' do
+      log_in_as(user)
+      expect do
+        delete "/api/v1/posts/#{post.id}", headers: xhr_header
+      end.to change(Post, :count).by(-1)
+      expect(response.status).to eq(204)
+    end
+
+    it 'reject an unauth user' do
+      delete "/api/v1/posts/#{post.id}", headers: xhr_header
+      expect(response.status).to eq(401)
+    end
+
+    it 'protect from CSRF' do
+      log_in_as(user)
+      delete "/api/v1/posts/#{post.id}"
+      expect(response.status).to eq(403)
+    end
+  end
+end

--- a/spec/support/test_helper.rb
+++ b/spec/support/test_helper.rb
@@ -1,0 +1,17 @@
+module TestHelper
+  def log_in_as(user)
+    allow_any_instance_of(ActionDispatch::Request).to receive(:session).and_return({ user_id: user.id })
+  end
+
+  def xhr_header
+    { 'X-Requested-With': 'XMLHttpRequest' }
+  end
+
+  def json_header
+    { 'Content-Type': 'application/json' }
+  end
+
+  def json(response)
+    JSON.parse(response.body)
+  end
+end


### PR DESCRIPTION
### 関連issue
#29 

### やったこと
- /api/v1/postsのテスト
  - GET /api/v1/posts
  - GET /api/v1/posts/:id
  - POST /api/v1/posts
  - PATCH /api/v1/posts/:id
  - DELETE /api/v1/posts/:id

### 参考
- [【Rails】APIテストの書き方](https://qiita.com/k-penguin-sato/items/defdb828bd54729272ad)
- [RSpecでヘルパーを作成する方法](https://breakthrough-tech.yuta-u.com/rspec/how-to-make-spec-support/)
- [Rubyのmoduleの使い方とメリットを理解して脱初心者！](https://techplay.jp/column/536)
- [Request specのget/postメソッドでリクエストヘッダーに値を設定するには](http://tokyo-bluelight.com/2018/08/27/request-spec%E3%81%AEgetpost%E3%81%A7requestheader%E3%82%92%E8%A8%AD%E5%AE%9A%E3%81%99%E3%82%8B/)
- [コントローラのテストをRequest specで書く際に、session値を設定する](https://qiita.com/nnnnnnnno8/items/080f87006ed68733cc7a)
- [RSpecの(describe/context/example/it)の使い分け](https://qiita.com/uchiko/items/d34c5d1298934252f58f)
- [letとlet!の使い分け(Ruby/Rspec)](https://papael14.com/how-to-use-the-let/)
- [rspec sessionの定義](https://na-ginnan.com/rails-rspec-session/)