### PR TITLE
/api/v1/sessionsのテスト

### DIFF
--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -12,7 +12,7 @@ module Api
         end
       end
 
-      def logged_in?
+      def logged_in
         render json: { logged_in: !current_user.nil? }
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,8 +3,11 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :users
-      resources :sessions
-      get 'logged_in', to: 'sessions#logged_in?'
+      resources :sessions do
+        collection do
+          get :logged_in
+        end
+      end
       resources :posts
     end
   end

--- a/frontend/src/contexts/AuthContext.js
+++ b/frontend/src/contexts/AuthContext.js
@@ -6,7 +6,7 @@ export const AuthContextProvider = ({ children }) => {
   const [loggedIn, setLoggedIn] = useState(null);
 
   useEffect(() => {
-    fetch(`${process.env.REACT_APP_API_URL}/logged_in`, {
+    fetch(`${process.env.REACT_APP_API_URL}/sessions/logged_in`, {
       method: 'GET',
       credentials: 'include',
       headers: {

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe '/api/v1/sessions', type: :request do
+  let!(:user) { create(:user) }
+
+  describe 'create' do
+    it 'accept a valid user' do
+      session_params = { session: { email: user.email, password: user.password } }
+      post '/api/v1/sessions', params: session_params.to_json, headers: xhr_header.merge(json_header)
+      expect(response.status).to eq(204)
+    end
+
+    it 'reject an invalid user' do
+      session_params = { session: { email: 'fake@example.com', password: 'fakepass' } }
+      post '/api/v1/sessions', params: session_params.to_json, headers: xhr_header.merge(json_header)
+      expect(response.status).to eq(401)
+    end
+
+    it 'protect from CSRF' do
+      session_params = { session: { email: user.email, password: user.password } }
+      post '/api/v1/sessions', params: session_params.to_json, headers: json_header
+      expect(response.status).to eq(403)
+    end
+  end
+
+  describe 'logged_in' do
+    it 'return true for an auth user' do
+      log_in_as(user)
+      get '/api/v1/sessions/logged_in', headers: xhr_header
+      expect(json(response)['logged_in']).to eq(true)
+    end
+
+    it 'return false for an unauth user' do
+      get '/api/v1/sessions/logged_in', headers: xhr_header
+      expect(json(response)['logged_in']).to eq(false)
+    end
+
+    it 'protect from CSRF' do
+      get '/api/v1/sessions/logged_in'
+      expect(response.status).to eq(403)
+    end
+  end
+end


### PR DESCRIPTION
### 関連issue
#29 

### やったこと
- ルーティングの変更
テストを書いていて、ルーティングが不自然な気がしたので、修正した。
(前) /api/v1/logged_in
(後) /api/v1/sessions/logged_in
logged_inはSessionsControllerに書いているので、sessionsの下に置くべきだと思ったので、この修正をした。
```ruby
resources :sessions do
  collection do
    get :logged_in
  end
end
```
SessionsControllerのメソッド名は初め、logged_in?だったので、`get :logged_in?`と書いたのだが、rails routesで、`Missing :action key on routes definition, please check your routes. (ArgumentError)`というエラーが出てしまった。?はクエリパラメータなので、ルーティングには使えないということだと思う。
- /api/v1/sessionsのテスト
  - POST /api/v1/sessions
  - GET /api/v1/sessions/logged_in

### 参考
- [git stashとconflict対処の実用ガイド](https://qiita.com/gngn/items/df0c4f3668a442b0dd50) (このPRには全く関係ないけど、使ったのでメモ)
- [railsのroutes.rbのmemberとcollectionの違いは?](https://qiita.com/k152744/items/141345e34fc0095217fe)
- [Rubyの関数名の感嘆符「!」と疑問符「?」の意味](https://ztbuz.hateblo.jp/entry/2013/12/28/112119)