### PR TITLE
Heroku上での問題を解決

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,13 +24,13 @@ gem 'bootsnap', '>= 1.4.4', require: false
 gem 'rack-cors'
 
 gem 'dotenv-rails'
+gem "factory_bot_rails"
 
 group :development, :test do
   gem 'sqlite3', '~> 1.4'
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem "rspec-rails"
-  gem "factory_bot_rails"
 end
 
 group :development do

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,7 @@
 class ApplicationController < ActionController::API
   include ActionController::MimeResponds
 
-  before_action :check_xhr_header
+  before_action :check_xhr_header, except: :fallback_index_html
 
   def fallback_index_html
     respond_to do |format|

--- a/frontend/.eslintrc
+++ b/frontend/.eslintrc
@@ -4,7 +4,7 @@
     "node": true,
     "es6": true
   },
-  "extends": ["eslint:recommended", "prettier", "plugin:react/recommended"],
+  "extends": ["eslint:recommended", "plugin:react/recommended", "prettier"],
   "parser": "babel-eslint",
   "parserOptions": {
     "sourceType": "module"


### PR DESCRIPTION
### 関連issue
#40 

### やったこと
- .eslintrcでエラーが発生し、デプロイできない問題は解決することができなかった。`extends`の中で、prettierを一番最後にしなければいけないようで、行ったが、解決しなかった。他にも、package.jsonでnodeやnpmのバージョンを指定したが、解決しなかった。prettierを一番最後にするのは、diffに含めた。
- factory_bot_railsをproduction環境でもインストールするようにGemfileを修正
- `fall_back_index_html`の前は、 `check_xhr_header`を実行しないようにする。

### 参考
- [Failed to load config "prettier" to extend from Referenced from: .../node_modules/eslint-plugin-prettier/eslint-plugin-prettier.js #253](https://github.com/prettier/eslint-plugin-prettier/issues/253)
- [ESLintとPrettierを併用するときの設定(eslint-plugin-prettier, eslint-config-prettier)](https://dackdive.hateblo.jp/entry/2019/03/15/100000)
- [HerokuはNode.jsのバージョンを指定してデプロイできる](https://relativelayout.hatenablog.com/entry/2018/11/08/092143)
- [package.json のチルダ(~) とキャレット(^)](https://qiita.com/sotarok/items/4ebd4cfedab186355867)
- [Heroku Node.js Support](https://devcenter.heroku.com/articles/nodejs-support#specifying-a-node-js-version)
- [【Rails】 before_actionの使い方とオプションについて](https://pikawaka.com/rails/before_action)
