### PR TITLE
設定画面を作成

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -3,6 +3,8 @@
 module Api
   module V1
     class UsersController < ApplicationController
+      before_action :require_login, only: :me
+
       def create
         user = User.new(user_params)
 
@@ -12,6 +14,10 @@ module Api
         else
           render json: user.errors, status: :bad_request
         end
+      end
+
+      def me
+        render json: current_user, status: :ok
       end
 
       private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,11 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   namespace :api do
     namespace :v1 do
-      resources :users
+      resources :users do
+        collection do
+          get :me
+        end
+      end
       resources :sessions do
         collection do
           get :logged_in

--- a/frontend/.eslintrc
+++ b/frontend/.eslintrc
@@ -10,7 +10,8 @@
     "sourceType": "module"
   },
   "globals": {
-    "fetch": false
+    "fetch": false,
+    "FileReader": false
   },
   "rules": {
     "react/prop-types": "off",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -5,6 +5,7 @@ import Top from './components/Top';
 import Signup from './components/Signup';
 import Login from './components/Login';
 import Home from './components/Home';
+import Setting from './components/Setting';
 import NotFound from './components/NotFound';
 
 const WaitInitialize = ({ children }) => {
@@ -43,6 +44,7 @@ const App = () => {
             <PublicRoute path='/signup' component={Signup} />
             <PublicRoute path='/login' component={Login} />
             <PrivateRoute path='/home' component={Home} />
+            <PrivateRoute path='/setting' component={Setting} />
             <Route component={NotFound} />
           </Switch>
         </BrowserRouter>

--- a/frontend/src/components/Setting.js
+++ b/frontend/src/components/Setting.js
@@ -1,0 +1,183 @@
+import React, { useState, useEffect } from 'react';
+import Grid from '@material-ui/core/Grid';
+import Button from '@material-ui/core/Button';
+import TextField from '@material-ui/core/TextField';
+import Icon from '../logo.svg';
+
+const Setting = () => {
+  const [inputValue, setInputValue] = useState({
+    name: '',
+    email: '',
+    password: '',
+    password_confirmation: '',
+  });
+  const [imageData, setImageData] = useState(null);
+
+  useEffect(() => {
+    fetch(`${process.env.REACT_APP_API_URL}/users/me`, {
+      method: 'GET',
+      credentials: 'include',
+      headers: {
+        'X-Requested-With': 'XMLHttpRequest',
+      },
+    })
+      .then((res) => res.json())
+      .then((res) => {
+        const newInputValue = {
+          name: '',
+          email: '',
+          password: '',
+          password_confirmation: '',
+        };
+        newInputValue.name = res.name;
+        newInputValue.email = res.email;
+        setInputValue(newInputValue);
+      });
+  }, []);
+
+  const changeInputValue = (itemName, e) => {
+    const newInputValue = Object.assign({}, inputValue);
+    newInputValue[itemName] = e.target.value;
+    setInputValue(newInputValue);
+  };
+
+  const onImageChange = (e) => {
+    const file = e.target.files[0];
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      setImageData(e.target.result);
+    };
+    reader.readAsDataURL(file);
+  };
+
+  const removeImage = () => {
+    setImageData(null);
+  };
+
+  const ImageRenderer = () => {
+    return (
+      <Grid
+        container
+        direction='column'
+        alignItems='center'
+        justifyContent='center'
+      >
+        <img
+          src={imageData ? imageData : Icon}
+          style={{
+            border: 'solid 1px',
+            borderRadius: '50%',
+            height: 300,
+            width: 300,
+            marginBottom: 20,
+          }}
+        />
+        <Button
+          variant='contained'
+          component='label'
+          color='primary'
+          style={{
+            width: 200,
+            marginLeft: 10,
+            marginBottom: 10,
+          }}
+        >
+          Upload
+          <input
+            type='file'
+            accept='image/*'
+            hidden
+            onChange={(e) => onImageChange(e)}
+          />
+        </Button>
+        <Button
+          variant='contained'
+          component='label'
+          color='secondary'
+          style={{
+            width: 200,
+            marginLeft: 10,
+            marginBottom: 30,
+          }}
+          onClick={removeImage}
+        >
+          Remove
+        </Button>
+      </Grid>
+    );
+  };
+
+  const InfoRenderer = () => {
+    return (
+      <Grid
+        container
+        direction='column'
+        alignItems='center'
+        justifyContent='center'
+      >
+        <TextField
+          label='ユーザー名'
+          variant='outlined'
+          style={{ width: '40ch', marginBottom: 30 }}
+          value={inputValue.name}
+          onChange={(e) => changeInputValue('name', e)}
+        />
+        <TextField
+          label='メールアドレス'
+          variant='outlined'
+          style={{ width: '40ch', marginBottom: 30 }}
+          value={inputValue.email}
+          onChange={(e) => changeInputValue('email', e)}
+        />
+        <TextField
+          label='パスワード変更'
+          type='password'
+          variant='outlined'
+          style={{ width: '40ch', marginBottom: 30 }}
+          value={inputValue.password}
+          onChange={(e) => changeInputValue('password', e)}
+        />
+        <TextField
+          label='パスワード変更(確認)'
+          type='password'
+          variant='outlined'
+          style={{ width: '40ch', marginBottom: 30 }}
+          value={inputValue.password_confirmation}
+          onChange={(e) => changeInputValue('password_confirmation', e)}
+        />
+      </Grid>
+    );
+  };
+
+  return (
+    <Grid
+      container
+      direction='column'
+      alignItems='center'
+      justifyContent='center'
+      style={{ marginTop: 100}}
+    >
+      <Grid
+        container
+        alignItems='center'
+        justifyContent='center'
+      >
+        <Grid item xs={12} sm={12} md={6} lg={5}>
+          <ImageRenderer />
+        </Grid>
+        <Grid item xs={12} sm={12} md={6} lg={5}>
+          <InfoRenderer />
+        </Grid>
+      </Grid>
+      <Button
+        variant='contained'
+        color='primary'
+        style={{ width: 300 }}
+      >
+        Update
+      </Button>
+    </Grid>
+  );
+};
+
+export default Setting;


### PR DESCRIPTION
### 関連issue
#42 

### やったこと
- ログイン中のユーザーを返すAPI(/api/v1/users/me)を実装
- 設定画面を作成
  - とりあえず、デフォルトのアイコン画像をReactのロゴにしてある
  - UPLOADボタンを押して、画像をアップロードすると、プレビューが更新される
  - DELETEボタンを押すと、デフォルトの画像になる
  - `FileReader`でESLintのエラー('FileReader' is not defined)が出たので、.eslintrcを修正
  - UPDATEボタンを押した時の動作は未実装

### UI
<img width="600" alt="スクリーンショット 2021-10-15 11 29 30" src="https://user-images.githubusercontent.com/61813626/137422975-24a195c5-a769-4447-92e5-47020db97212.png">

幅が小さい時
<img width="300" alt="スクリーンショット 2021-10-15 11 43 53" src="https://user-images.githubusercontent.com/61813626/137424167-2c1e86da-a301-4dcb-af16-ee35d207651f.png">

### 備考
Reactの画像は、src配下しか参照できない

### 参考
- [Meterial-UIを使うときのポイント～Grid編～](https://weblion303.net/1236)
- [ESLint 最初の一歩](https://qiita.com/mysticatea/items/f523dab04a25f617c87d)
- [onclickとonsubmitの違いは何ですか？](https://www.webdevqa.jp.net/ja/javascript/onclick%E3%81%A8onsubmit%E3%81%AE%E9%81%95%E3%81%84%E3%81%AF%E4%BD%95%E3%81%A7%E3%81%99%E3%81%8B%EF%BC%9F/1047483458/)
- [たった2ステップ！React.js で選択画像をプレビューする方法（サンプルDL可）](https://blog.capilano-fw.com/?p=2574)
- [ReactでFileのアップロードボタンをカスタマイズする](https://zenn.dev/dove/articles/1927889e1c4153)
- [React + Material UIでファイル送信ボタン](https://qiita.com/Garyuten/items/a1ca3bc34185f77598f7)
- [画像を丸く円形にくり抜いて表示するCSS](https://www.nishishi.com/css/trim-image-to-circle.html)
- [Reactで画像を表示する方法](https://www.atnr.net/how-to-display-images-on-react/)