### PR TITLE
ポートフォリオ投稿フォームの作成

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2356,6 +2356,14 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/codemirror": {
+      "version": "0.0.109",
+      "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-0.0.109.tgz",
+      "integrity": "sha512-cSdiHeeLjvGn649lRTNeYrVCDOgDrtP+bDDSFDd1TF+i0jKGPDRozno2NOJ9lTniso+taiv4kiVS8dgM8Jm5lg==",
+      "requires": {
+        "@types/tern": "*"
+      }
+    },
     "@types/eslint": {
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.28.0.tgz",
@@ -2431,6 +2439,11 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
+    },
+    "@types/marked": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-2.0.5.tgz",
+      "integrity": "sha512-shRZ7XnYFD/8n8zSjKvFdto1QNSf4tONZIlNEZGrJe8GsOE8DL/hG1Hbl8gZlfLnjS7+f5tZGIaTgfpyW38h4w=="
     },
     "@types/minimatch": {
       "version": "3.0.5",
@@ -2519,6 +2532,14 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.8.tgz",
       "integrity": "sha512-ipixuVrh2OdNmauvtT51o3d8z12p6LtFW9in7U79der/kwejjdNchQC5UMn5u/KxNoM7VHHOs/l8KS8uHxhODQ=="
+    },
+    "@types/tern": {
+      "version": "0.23.4",
+      "resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.4.tgz",
+      "integrity": "sha512-JAUw1iXGO1qaWwEOzxTKJZ/5JxVeON9kvGZ/osgZaJImBnyjyn0cjovPsf6FNLmyGY8Vw9DoXZCMlfMkMwHRWg==",
+      "requires": {
+        "@types/estree": "*"
+      }
     },
     "@types/testing-library__jest-dom": {
       "version": "5.14.1",
@@ -4288,6 +4309,19 @@
         }
       }
     },
+    "codemirror": {
+      "version": "5.63.3",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.63.3.tgz",
+      "integrity": "sha512-1C+LELr+5grgJYqwZKqxrcbPsHFHapVaVAloBsFBASbpLnQqLw1U8yXJ3gT5D+rhxIiSpo+kTqN+hQ+9ialIXw=="
+    },
+    "codemirror-spell-checker": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/codemirror-spell-checker/-/codemirror-spell-checker-1.1.2.tgz",
+      "integrity": "sha1-HGYPkIlIPMtRE7m6nKGcP0mTNx4=",
+      "requires": {
+        "typo-js": "*"
+      }
+    },
     "collect-v8-coverage": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz",
@@ -5335,6 +5369,11 @@
         }
       }
     },
+    "dompurify": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.3.3.tgz",
+      "integrity": "sha512-dqnqRkPMAjOZE0FogZ+ceJNM2dZ3V/yNOuFB7+39qpO93hHhfRpHw3heYQC7DPK9FqbQTfBKUJhiSfz4MvXYwg=="
+    },
     "domutils": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
@@ -5392,6 +5431,25 @@
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0",
         "stream-shift": "^1.0.0"
+      }
+    },
+    "easymde": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/easymde/-/easymde-2.15.0.tgz",
+      "integrity": "sha512-9jMRIVvKt1d0UjRN45yotUYECAM4xvw0TTAQw8sYDONP++keWJVnd8Xrn+V+vQEN/v9/X0SWEoo1rFSgCooGpw==",
+      "requires": {
+        "@types/codemirror": "0.0.109",
+        "@types/marked": "^2.0.2",
+        "codemirror": "^5.61.0",
+        "codemirror-spell-checker": "1.1.2",
+        "marked": "^2.0.3"
+      },
+      "dependencies": {
+        "marked": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-2.1.3.tgz",
+          "integrity": "sha512-/Q+7MGzaETqifOMWYEA7HVMaZb4XbcRfaOzcSsHZEith83KGlvaSG33u0SKu89Mj5h+T8V2hM+8O45Qc5XTgwA=="
+        }
       }
     },
     "ee-first": {
@@ -7259,6 +7317,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ=="
+    },
+    "highlight.js": {
+      "version": "11.3.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.3.1.tgz",
+      "integrity": "sha512-PUhCRnPjLtiLHZAQ5A/Dt5F8cWZeMyj9KRsACsWT+OD6OP0x6dp5OmT5jdx0JgEyPxPZZIPQpRN2TciUT7occw=="
     },
     "history": {
       "version": "4.10.1",
@@ -10214,6 +10277,11 @@
         "object-visit": "^1.0.0"
       }
     },
+    "marked": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-3.0.7.tgz",
+      "integrity": "sha512-ctKqbnLuNbsHbI26cfMyOlKgXGfl1orOv1AvWWDX7AkgfMOwCWvmuYc+mVLeWhQ9W6hdWVBynOs96VkcscKo0Q=="
+    },
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -12953,6 +13021,15 @@
         "workbox-webpack-plugin": "5.1.4"
       }
     },
+    "react-simplemde-editor": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/react-simplemde-editor/-/react-simplemde-editor-5.0.2.tgz",
+      "integrity": "sha512-yaqZSaUBf6B0kQY0mH8WP/nHnvJFz48aO8cMYCL1e/AFiuB/H8UDuyZFP9/exOtwVpaG373HYR1YedKMtCh+Kw==",
+      "requires": {
+        "@types/codemirror": "0.0.109",
+        "@types/marked": "^2.0.2"
+      }
+    },
     "react-transition-group": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.2.tgz",
@@ -15156,6 +15233,11 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
+    },
+    "typo-js": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/typo-js/-/typo-js-1.2.0.tgz",
+      "integrity": "sha512-dELuLBVa2jvWdU/CHTKi2L/POYaRupv942k+vRsFXsM17acXesQGAiGCio82RW7fvcr7bkuD/Zj8XpUh6aPC2A=="
     },
     "unbox-primitive": {
       "version": "1.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,10 +7,15 @@
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
+    "dompurify": "^2.3.3",
+    "easymde": "^2.15.0",
+    "highlight.js": "^11.3.1",
+    "marked": "^3.0.7",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-router-dom": "^5.3.0",
     "react-scripts": "4.0.3",
+    "react-simplemde-editor": "^5.0.2",
     "web-vitals": "^1.0.1"
   },
   "scripts": {

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -6,6 +6,7 @@ import Signup from './components/Signup';
 import Login from './components/Login';
 import Home from './components/Home';
 import Setting from './components/Setting';
+import PostForm from './components/PostForm';
 import NotFound from './components/NotFound';
 
 const WaitInitialize = ({ children }) => {
@@ -45,6 +46,7 @@ const App = () => {
             <PublicRoute path='/login' component={Login} />
             <PrivateRoute path='/home' component={Home} />
             <PrivateRoute path='/setting' component={Setting} />
+            <PrivateRoute path='/posts/new' component={PostForm} />
             <Route component={NotFound} />
           </Switch>
         </BrowserRouter>

--- a/frontend/src/components/PostForm.js
+++ b/frontend/src/components/PostForm.js
@@ -1,0 +1,34 @@
+import React, { useState } from 'react';
+import SimpleMDE from 'react-simplemde-editor';
+import 'easymde/dist/easymde.min.css';
+import Grid from '@material-ui/core/Grid';
+import TextField from '@material-ui/core/TextField';
+import Button from '@material-ui/core/Button';
+
+const PostForm = () => {
+  const style = {
+    display: 'flex',
+    flexDirection: 'column',
+    minHeight: '100vh',
+  };
+
+  const [markdown, setMarkdown] = useState();
+
+  return (
+    <Grid container alignItems='center' justifyContent='center' style={style}>
+      1. アプリ名を入力してください。
+      <TextField variant='outlined' style={{ width: 400, marginBottom: 30 }} />
+      2. デプロイ先のURLを入力してください。
+      <TextField variant='outlined' style={{ width: 400, marginBottom: 30 }} />
+      3. レポジトリのURLを入力してください。
+      <TextField variant='outlined' style={{ width: 400, marginBottom: 30 }} />
+      4. アプリの概要や工夫点を入力してください。
+      <SimpleMDE value={markdown} onChange={(e) => setMarkdown(e)} />
+      <Button variant='contained' color='primary'>
+        送信
+      </Button>
+    </Grid>
+  );
+};
+
+export default PostForm;


### PR DESCRIPTION
### 関連issue
#50 

### やったこと
- ポートフォリオ投稿フォームの作成(/posts/new)

### UI
<img width="200" alt="スクリーンショット 2021-10-20 10 15 54" src="https://user-images.githubusercontent.com/61813626/138011843-c3ca7800-adbd-4a93-80cf-794504f4e61b.png">

### 備考
入力した文字が赤くなる仕様がSimpleMDEにあり、外したいがやり方が分からない
<img width="200" alt="スクリーンショット 2021-10-20 10 16 32" src="https://user-images.githubusercontent.com/61813626/138012025-4e041287-cce3-4ad0-bac3-deb691775dc6.png">

### 参考
- [Reactでマークダウンエディタを作ってみよう](https://zenn.dev/rinka/articles/b260e200cb5258)
