### PR TITLE
ユーザー情報の更新処理を実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,8 @@ gem 'rack-cors'
 
 gem 'dotenv-rails'
 gem "factory_bot_rails"
+gem 'carrierwave'
+gem 'mini_magick'
 
 group :development, :test do
   gem 'sqlite3', '~> 1.4'
@@ -44,6 +46,7 @@ end
 
 group :production do
   gem 'pg'
+  gem 'fog'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    CFPropertyList (2.3.6)
     actioncable (6.1.4.1)
       actionpack (= 6.1.4.1)
       activesupport (= 6.1.4.1)
@@ -60,30 +61,236 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
+    addressable (2.8.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    aliyun-sdk (0.8.0)
+      nokogiri (~> 1.6)
+      rest-client (~> 2.0)
     ast (2.4.2)
     bcrypt (3.1.16)
     bootsnap (1.9.1)
       msgpack (~> 1.0)
     builder (3.2.4)
     byebug (11.1.3)
+    carrierwave (2.2.2)
+      activemodel (>= 5.0.0)
+      activesupport (>= 5.0.0)
+      addressable (~> 2.6)
+      image_processing (~> 1.1)
+      marcel (~> 1.0.0)
+      mini_mime (>= 0.1.3)
+      ssrf_filter (~> 1.0)
     concurrent-ruby (1.1.9)
     crass (1.0.6)
+    declarative (0.0.20)
     diff-lcs (1.4.4)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
     dotenv (2.7.6)
     dotenv-rails (2.7.6)
       dotenv (= 2.7.6)
       railties (>= 3.2)
+    dry-inflector (0.2.1)
     erubi (1.10.0)
+    excon (0.87.0)
     factory_bot (6.2.0)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
+    faraday (0.17.4)
+      multipart-post (>= 1.2, < 3)
     ffi (1.15.4)
+    fission (0.5.0)
+      CFPropertyList (~> 2.2)
+    fog (2.2.0)
+      fog-aliyun (>= 0.1.0)
+      fog-atmos
+      fog-aws (>= 0.6.0)
+      fog-brightbox (~> 0.4)
+      fog-cloudatcost (~> 0.4)
+      fog-cloudstack (~> 0.1.0)
+      fog-core (~> 2.1)
+      fog-digitalocean (>= 0.3.0)
+      fog-dnsimple (~> 2.1)
+      fog-dynect (~> 0.0.2)
+      fog-ecloud (~> 0.1)
+      fog-google (~> 1.0)
+      fog-internet-archive
+      fog-json
+      fog-local
+      fog-openstack
+      fog-ovirt
+      fog-powerdns (>= 0.1.1)
+      fog-profitbricks
+      fog-rackspace
+      fog-radosgw (>= 0.0.2)
+      fog-riakcs
+      fog-sakuracloud (>= 0.0.4)
+      fog-serverlove
+      fog-softlayer
+      fog-storm_on_demand
+      fog-terremark
+      fog-vmfusion
+      fog-voxel
+      fog-vsphere (>= 0.4.0)
+      fog-xenserver
+      fog-xml (~> 0.1.1)
+      ipaddress (~> 0.5)
+      json (~> 2.0)
+    fog-aliyun (0.3.19)
+      aliyun-sdk (~> 0.8.0)
+      fog-core
+      fog-json
+      ipaddress (~> 0.8)
+      xml-simple (~> 1.1)
+    fog-atmos (0.1.0)
+      fog-core
+      fog-xml
+    fog-aws (3.12.0)
+      fog-core (~> 2.1)
+      fog-json (~> 1.1)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-brightbox (0.16.1)
+      dry-inflector
+      fog-core
+      fog-json
+      mime-types
+    fog-cloudatcost (0.4.0)
+      fog-core
+      fog-json
+      ipaddress
+    fog-cloudstack (0.1.0)
+      fog-core (~> 2.1)
+      fog-json (~> 1.1)
+      fog-xml (~> 0.1)
+    fog-core (2.2.4)
+      builder
+      excon (~> 0.71)
+      formatador (~> 0.2)
+      mime-types
+    fog-digitalocean (0.4.0)
+      fog-core
+      fog-json
+      fog-xml
+      ipaddress (>= 0.5)
+    fog-dnsimple (2.1.0)
+      fog-core (>= 1.38, < 3)
+      fog-json
+    fog-dynect (0.0.3)
+      fog-core
+      fog-json
+      fog-xml
+    fog-ecloud (0.3.0)
+      fog-core
+      fog-xml
+    fog-google (1.7.1)
+      fog-core
+      fog-json
+      fog-xml
+      google-api-client (~> 0.23.0)
+    fog-internet-archive (0.0.2)
+      fog-core
+      fog-json
+      fog-xml
+    fog-json (1.2.0)
+      fog-core
+      multi_json (~> 1.10)
+    fog-local (0.7.0)
+      fog-core (>= 1.27, < 3.0)
+    fog-openstack (1.0.11)
+      fog-core (~> 2.1)
+      fog-json (>= 1.0)
+      ipaddress (>= 0.8)
+    fog-ovirt (2.0.1)
+      activesupport
+      fog-core
+      fog-json
+      fog-xml
+      ovirt-engine-sdk (>= 4.3.1)
+    fog-powerdns (0.2.0)
+      fog-core
+      fog-json
+      fog-xml
+    fog-profitbricks (0.0.5)
+      fog-core
+      fog-xml
+      nokogiri
+    fog-rackspace (0.1.6)
+      fog-core (>= 1.35)
+      fog-json (>= 1.0)
+      fog-xml (>= 0.1)
+      ipaddress (>= 0.8)
+    fog-radosgw (0.0.5)
+      fog-core (>= 1.21.0)
+      fog-json
+      fog-xml (>= 0.0.1)
+    fog-riakcs (0.1.0)
+      fog-core
+      fog-json
+      fog-xml
+    fog-sakuracloud (1.7.5)
+      fog-core
+      fog-json
+    fog-serverlove (0.1.2)
+      fog-core
+      fog-json
+    fog-softlayer (1.1.4)
+      fog-core
+      fog-json
+    fog-storm_on_demand (0.1.1)
+      fog-core
+      fog-json
+    fog-terremark (0.1.0)
+      fog-core
+      fog-xml
+    fog-vmfusion (0.1.0)
+      fission
+      fog-core
+    fog-voxel (0.1.0)
+      fog-core
+      fog-xml
+    fog-vsphere (3.5.0)
+      fog-core
+      rbvmomi (>= 1.9, < 3)
+    fog-xenserver (1.0.0)
+      fog-core
+      fog-xml
+      xmlrpc
+    fog-xml (0.1.4)
+      fog-core
+      nokogiri (>= 1.5.11, < 2.0.0)
+    formatador (0.3.0)
     globalid (0.5.2)
       activesupport (>= 5.0)
+    google-api-client (0.23.9)
+      addressable (~> 2.5, >= 2.5.1)
+      googleauth (>= 0.5, < 0.7.0)
+      httpclient (>= 2.8.1, < 3.0)
+      mime-types (~> 3.0)
+      representable (~> 3.0)
+      retriable (>= 2.0, < 4.0)
+      signet (~> 0.9)
+    googleauth (0.6.7)
+      faraday (~> 0.12)
+      jwt (>= 1.4, < 3.0)
+      memoist (~> 0.16)
+      multi_json (~> 1.11)
+      os (>= 0.9, < 2.0)
+      signet (~> 0.7)
+    http-accept (1.7.0)
+    http-cookie (1.0.4)
+      domain_name (~> 0.5)
+    httpclient (2.8.3)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
+    image_processing (1.12.1)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
+    ipaddress (0.8.3)
+    json (2.6.0)
+    jwt (2.3.0)
     listen (3.7.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -93,19 +300,32 @@ GEM
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
+    memoist (0.16.2)
     method_source (1.0.0)
+    mime-types (3.3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2021.0901)
+    mini_magick (4.11.0)
     mini_mime (1.1.1)
     minitest (5.14.4)
     msgpack (1.4.2)
+    multi_json (1.15.0)
+    multipart-post (2.1.1)
+    netrc (0.11.0)
     nio4r (2.5.8)
     nokogiri (1.12.4-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.12.4-x86_64-linux)
       racc (~> 1.4)
+    optimist (3.0.1)
+    os (1.1.1)
+    ovirt-engine-sdk (4.4.1)
+      json (>= 1, < 3)
     parallel (1.21.0)
     parser (3.0.2.0)
       ast (~> 2.4.1)
     pg (1.2.3)
+    public_suffix (4.0.6)
     puma (5.5.0)
       nio4r (~> 2.0)
     racc (1.5.2)
@@ -145,7 +365,22 @@ GEM
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    rbvmomi (2.4.1)
+      builder (~> 3.0)
+      json (>= 1.8)
+      nokogiri (~> 1.5)
+      optimist (~> 3.0)
     regexp_parser (2.1.1)
+    representable (3.1.1)
+      declarative (< 0.1.0)
+      trailblazer-option (>= 0.1.1, < 0.2.0)
+      uber (< 0.2.0)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
+    retriable (3.1.2)
     rexml (3.2.5)
     rspec-core (3.10.1)
       rspec-support (~> 3.10.0)
@@ -182,6 +417,13 @@ GEM
     rubocop-rspec (2.5.0)
       rubocop (~> 1.19)
     ruby-progressbar (1.11.0)
+    ruby-vips (2.1.3)
+      ffi (~> 1.12)
+    signet (0.16.0)
+      addressable (~> 2.8)
+      faraday (>= 0.17.3, < 2.0)
+      jwt (>= 1.5, < 3.0)
+      multi_json (~> 1.10)
     spring (3.0.0)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
@@ -191,13 +433,24 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     sqlite3 (1.4.2)
+    ssrf_filter (1.0.7)
     thor (1.1.0)
+    trailblazer-option (0.1.1)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
+    uber (0.1.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.8)
     unicode-display_width (2.1.0)
+    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    xml-simple (1.1.9)
+      rexml
+    xmlrpc (0.3.2)
+      webrick
     zeitwerk (2.4.2)
 
 PLATFORMS
@@ -208,9 +461,12 @@ DEPENDENCIES
   bcrypt (~> 3.1.7)
   bootsnap (>= 1.4.4)
   byebug
+  carrierwave
   dotenv-rails
   factory_bot_rails
+  fog
   listen (~> 3.3)
+  mini_magick
   pg
   puma (~> 5.0)
   rack-cors

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -20,6 +20,14 @@ module Api
         render json: current_user, status: :ok
       end
 
+      def update_me
+        if current_user.update(user_params)
+          render status: :ok, json: current_user
+        else
+          render status: :bad_request, json: current_user.errors
+        end
+      end
+
       private
 
       def user_params
@@ -28,6 +36,7 @@ module Api
           :email,
           :password,
           :password_confirmation,
+          :icon
         )
       end
     end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -3,7 +3,7 @@
 module Api
   module V1
     class UsersController < ApplicationController
-      before_action :require_login, only: :me
+      before_action :require_login, only: :show_me
 
       def create
         user = User.new(user_params)
@@ -16,7 +16,7 @@ module Api
         end
       end
 
-      def me
+      def show_me
         render json: current_user, status: :ok
       end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,4 +12,5 @@ class User < ApplicationRecord
   }
   has_secure_password
   validates :password, { presence: true, length: { minimum: 6 } }
+  mount_uploader :icon, IconUploader
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,6 @@ class User < ApplicationRecord
     uniqueness: true,
   }
   has_secure_password
-  validates :password, { presence: true, length: { minimum: 6 } }
+  validates :password, { presence: true, length: { minimum: 6 }, allow_nil: true }
   mount_uploader :icon, IconUploader
 end

--- a/app/uploaders/icon_uploader.rb
+++ b/app/uploaders/icon_uploader.rb
@@ -1,0 +1,47 @@
+class IconUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  # include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  storage :file
+  # storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # Add an allowlist of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  # def extension_allowlist
+  #   %w(jpg jpeg gif png)
+  # end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg" if original_filename
+  # end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       post '/users', to: 'users#create'
       get '/users/me', to: 'users#show_me'
+      patch '/users/me', to: 'users#update_me'
       resources :sessions do
         collection do
           get :logged_in

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,11 +4,8 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   namespace :api do
     namespace :v1 do
-      resources :users do
-        collection do
-          get :me
-        end
-      end
+      post '/users', to: 'users#create'
+      get '/users/me', to: 'users#show_me'
       resources :sessions do
         collection do
           get :logged_in

--- a/db/migrate/20211021044407_add_icon_to_users.rb
+++ b/db/migrate/20211021044407_add_icon_to_users.rb
@@ -1,0 +1,5 @@
+class AddIconToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :icon, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_08_191141) do
+ActiveRecord::Schema.define(version: 2021_10_21_044407) do
 
   create_table "posts", force: :cascade do |t|
     t.string "title", null: false
@@ -27,6 +27,7 @@ ActiveRecord::Schema.define(version: 2021_10_08_191141) do
     t.string "password_digest", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "icon"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/frontend/.eslintrc
+++ b/frontend/.eslintrc
@@ -11,7 +11,8 @@
   },
   "globals": {
     "fetch": false,
-    "FileReader": false
+    "FileReader": false,
+    "FormData": false
   },
   "rules": {
     "react/prop-types": "off",

--- a/frontend/src/components/Setting.js
+++ b/frontend/src/components/Setting.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import Grid from '@material-ui/core/Grid';
 import Button from '@material-ui/core/Button';
 import TextField from '@material-ui/core/TextField';
-import Icon from '../logo.svg';
+import defaultIcon from '../logo.svg';
 
 const Setting = () => {
   const [inputValue, setInputValue] = useState({
@@ -12,7 +12,7 @@ const Setting = () => {
     password_confirmation: '',
   });
   const [icon, setIcon] = useState(null);
-  const [imageData, setImageData] = useState(null);
+  const [updateIcon, setUpdateIcon] = useState(null);
 
   useEffect(() => {
     fetch(`${process.env.REACT_APP_API_URL}/users/me`, {
@@ -47,13 +47,13 @@ const Setting = () => {
     const file = e.target.files[0];
     const reader = new FileReader();
     reader.onload = (e) => {
-      setImageData(e.target.result);
+      setUpdateIcon(e.target.result);
     };
     reader.readAsDataURL(file);
   };
 
   const removeImage = () => {
-    setImageData(null);
+    setUpdateIcon(null);
   };
 
   return (
@@ -68,7 +68,7 @@ const Setting = () => {
         <Grid item xs={12} sm={12} md={6} lg={5}>
           <ImageRenderer
             icon={icon}
-            imageData={imageData}
+            updateIcon={updateIcon}
             onImageChange={onImageChange}
             removeImage={removeImage}
           />
@@ -93,7 +93,11 @@ const Setting = () => {
 
 const ImageRenderer = (props) => {
   const imageSource = () => {
-    return props.imageData ? props.imageData : props.icon ? props.icon : Icon;
+    return props.updateIcon
+      ? props.updateIcon
+      : props.icon
+      ? props.icon
+      : defaultIcon;
   };
 
   return (

--- a/frontend/src/components/Setting.js
+++ b/frontend/src/components/Setting.js
@@ -36,6 +36,24 @@ const Setting = () => {
       });
   }, []);
 
+  const updateProfile = () => {
+    const formData = new FormData();
+    formData.append('user[name]', inputValue.name);
+    formData.append('user[email]', inputValue.email);
+    formData.append('user[password]', inputValue.password);
+    formData.append('user[password_confirmation]', inputValue.password_confirmation);
+    if (icon) formData.append('user[icon]', icon);
+
+    fetch(`${process.env.REACT_APP_API_URL}/users/me`, {
+      method: 'PATCH',
+      credentials: 'include',
+      headers: {
+        'X-Requested-With': 'XMLHttpRequest',
+      },
+      body: formData
+    });
+  };
+
   const changeInputValue = (itemName, e) => {
     const newInputValue = Object.assign({}, inputValue);
     newInputValue[itemName] = e.target.value;
@@ -77,6 +95,7 @@ const Setting = () => {
         variant='contained'
         color='primary'
         style={{ width: 300, marginBottom: 30 }}
+        onClick={updateProfile}
       >
         Update
       </Button>

--- a/frontend/src/components/Setting.js
+++ b/frontend/src/components/Setting.js
@@ -11,6 +11,12 @@ const Setting = () => {
     password: '',
     password_confirmation: '',
   });
+  const [validationMessage, setValidationMessage] = useState({
+    name: '',
+    email: '',
+    password: '',
+    password_confirmation: '',
+  });
   const [icon, setIcon] = useState(null);
 
   useEffect(() => {
@@ -51,6 +57,34 @@ const Setting = () => {
         'X-Requested-With': 'XMLHttpRequest',
       },
       body: formData
+    }).then((res)=>{
+      if (res.status === 200) {
+        const newInputValue = Object.assign({}, inputValue);
+        newInputValue.password = '';
+        newInputValue.password_confirmation = '';
+        setInputValue(newInputValue);
+        const newValidationMessage = {
+          name: '',
+          email: '',
+          password: '',
+          password_confirmation: '',
+        };
+        setValidationMessage(newValidationMessage);
+      } else if (res.status === 400) {
+        res.json().then((err) => {
+          const newValidationMessage = {
+            name: '',
+            email: '',
+            password: '',
+            password_confirmation: '',
+          };
+          for (const property in err) {
+            newValidationMessage[property] = err[property][0];
+          }
+          console.log(newValidationMessage)
+          setValidationMessage(newValidationMessage);
+        })
+      }
     });
   };
 
@@ -88,6 +122,7 @@ const Setting = () => {
           <InfoRenderer
             inputValue={inputValue}
             changeInputValue={changeInputValue}
+            validationMessage={validationMessage}
           />
         </Grid>
       </Grid>
@@ -165,6 +200,8 @@ const InfoRenderer = (props) => {
         style={{ width: '40ch', marginBottom: 30 }}
         value={props.inputValue.name}
         onChange={(e) => props.changeInputValue('name', e)}
+        error={props.validationMessage.name !== ''}
+        helperText={props.validationMessage.name}
       />
       <TextField
         label='メールアドレス'
@@ -172,6 +209,8 @@ const InfoRenderer = (props) => {
         style={{ width: '40ch', marginBottom: 30 }}
         value={props.inputValue.email}
         onChange={(e) => props.changeInputValue('email', e)}
+        error={props.validationMessage.email !== ''}
+        helperText={props.validationMessage.email}
       />
       <TextField
         label='パスワード変更'
@@ -180,6 +219,8 @@ const InfoRenderer = (props) => {
         style={{ width: '40ch', marginBottom: 30 }}
         value={props.inputValue.password}
         onChange={(e) => props.changeInputValue('password', e)}
+        error={props.validationMessage.password !== ''}
+        helperText={props.validationMessage.password}
       />
       <TextField
         label='パスワード変更(確認)'
@@ -188,6 +229,8 @@ const InfoRenderer = (props) => {
         style={{ width: '40ch', marginBottom: 30 }}
         value={props.inputValue.password_confirmation}
         onChange={(e) => props.changeInputValue('password_confirmation', e)}
+        error={props.validationMessage.password_confirmation !== ''}
+        helperText={props.validationMessage.password_confirmation}
       />
     </Grid>
   );

--- a/frontend/src/components/Setting.js
+++ b/frontend/src/components/Setting.js
@@ -11,6 +11,7 @@ const Setting = () => {
     password: '',
     password_confirmation: '',
   });
+  const [icon, setIcon] = useState(null);
   const [imageData, setImageData] = useState(null);
 
   useEffect(() => {
@@ -32,6 +33,7 @@ const Setting = () => {
         newInputValue.name = res.name;
         newInputValue.email = res.email;
         setInputValue(newInputValue);
+        setIcon(res.icon);
       });
   }, []);
 
@@ -65,6 +67,7 @@ const Setting = () => {
       <Grid container alignItems='center' justifyContent='center'>
         <Grid item xs={12} sm={12} md={6} lg={5}>
           <ImageRenderer
+            icon={icon}
             imageData={imageData}
             onImageChange={onImageChange}
             removeImage={removeImage}
@@ -89,6 +92,10 @@ const Setting = () => {
 };
 
 const ImageRenderer = (props) => {
+  const imageSource = () => {
+    return props.imageData ? props.imageData : props.icon ? props.icon : Icon;
+  };
+
   return (
     <Grid
       container
@@ -97,7 +104,7 @@ const ImageRenderer = (props) => {
       justifyContent='center'
     >
       <img
-        src={props.imageData ? props.imageData : Icon}
+        src={imageSource()}
         style={{
           border: 'solid 1px',
           borderRadius: '50%',

--- a/frontend/src/components/Setting.js
+++ b/frontend/src/components/Setting.js
@@ -12,7 +12,6 @@ const Setting = () => {
     password_confirmation: '',
   });
   const [icon, setIcon] = useState(null);
-  const [updateIcon, setUpdateIcon] = useState(null);
 
   useEffect(() => {
     fetch(`${process.env.REACT_APP_API_URL}/users/me`, {
@@ -47,13 +46,9 @@ const Setting = () => {
     const file = e.target.files[0];
     const reader = new FileReader();
     reader.onload = (e) => {
-      setUpdateIcon(e.target.result);
+      setIcon(e.target.result);
     };
     reader.readAsDataURL(file);
-  };
-
-  const removeImage = () => {
-    setUpdateIcon(null);
   };
 
   return (
@@ -68,9 +63,7 @@ const Setting = () => {
         <Grid item xs={12} sm={12} md={6} lg={5}>
           <ImageRenderer
             icon={icon}
-            updateIcon={updateIcon}
             onImageChange={onImageChange}
-            removeImage={removeImage}
           />
         </Grid>
         <Grid item xs={12} sm={12} md={6} lg={5}>
@@ -124,7 +117,7 @@ const ImageRenderer = (props) => {
         style={{
           width: 200,
           marginLeft: 10,
-          marginBottom: 10,
+          marginBottom: 30,
         }}
       >
         Upload
@@ -134,19 +127,6 @@ const ImageRenderer = (props) => {
           hidden
           onChange={(e) => props.onImageChange(e)}
         />
-      </Button>
-      <Button
-        variant='contained'
-        component='label'
-        color='secondary'
-        style={{
-          width: 200,
-          marginLeft: 10,
-          marginBottom: 30,
-        }}
-        onClick={props.removeImage}
-      >
-        Remove
       </Button>
     </Grid>
   );


### PR DESCRIPTION
### 関連issue
#44 

### やったこと
- usersテーブルにiconカラムを追加
- ユーザー情報を更新する処理(PATCH /api/v1/users/me)を実装
- /settingでUPDATEボタンを押すと、ユーザー情報が更新されるようにした
- /settingのDELETEボタンは仕様が分からなくなったので、一旦削除(DELETEを押すとシステム上のデフォルトの画像に戻ることを考えていたが、アップロードされた画像を前に設定していた画像に戻すことも考えられる) 

### 備考
ユーザー名, メールアドレスの更新、パスワードの更新、画像の更新はページを分けた方が良いかもしれない([参考](https://atcoder.jp/settings))

### 参考
- [マイクロポストの画像投稿](https://railstutorial.jp/chapters/user_microposts?version=5.1#sec-micropost_images)
- [Railsのルーティングをカスタマイズしたときのメモ](https://qiita.com/dkurata38/items/273f380853f24bc69da8)
- [【Node.js】FetchでフォームデータをPOSTする](https://qiita.com/risto24/items/50ffafd0e045b2c0709f)
- [[フロントエンド] multipart/form-dataを理解してみよう](https://www.yoheim.net/blog.php?q=20171201)
- [Fetch APIでファイルをアップロードする時にContent-Typeを指定しないほうが良い](https://blog.mizukami.sh/entry/2019/01/15/Fetch_API%E3%81%A7%E3%83%95%E3%82%A1%E3%82%A4%E3%83%AB%E3%82%92%E3%82%A2%E3%83%83%E3%83%97%E3%83%AD%E3%83%BC%E3%83%89%E3%81%99%E3%82%8B%E6%99%82%E3%81%ABContent-Type%E3%82%92%E6%8C%87%E5%AE%9A%E3%81%97)
- [nil empty blankの違い](https://qiita.com/tsuchinoko_run/items/c9214379a1f2878ec4ee)
- [Railsバリデーションまとめ](https://qiita.com/ryuuuuuuuuuu/items/b7b985465fc0bf6dcaf8)
- [has_secure_passowordでのpasswordのvalidation](http://www.utsushiiro.jp/blog/archives/211)
- [has_secure_passwordとpresenceとallow_nilと私。](https://qiita.com/KH14/items/7fd6b4d6c4263f936ff4)