### PR TITLE
投稿詳細ページの作成

### DIFF
--- a/app/controllers/api/v1/posts_controller.rb
+++ b/app/controllers/api/v1/posts_controller.rb
@@ -16,7 +16,7 @@ module Api
 
       def show
         post = Post.find(params[:id])
-        render staus: 200, json: post
+        render staus: 200, json: { post: post, user: post.user }
       end
 
       def create

--- a/app/controllers/api/v1/posts_controller.rb
+++ b/app/controllers/api/v1/posts_controller.rb
@@ -16,7 +16,7 @@ module Api
 
       def show
         post = Post.find(params[:id])
-        render staus: 200, json: { post: post, user: post.user }
+        render staus: :ok, json: { post: post, user: post.user }
       end
 
       def create

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -6,6 +6,7 @@ import Top from './components/Top';
 import Signup from './components/Signup';
 import Login from './components/Login';
 import Home from './components/Home';
+import PostDetail from './components/PostDetail';
 import Setting from './components/Setting';
 import PostForm from './components/PostForm';
 import NotFound from './components/NotFound';
@@ -54,6 +55,7 @@ const App = () => {
                 <PrivateRoute path='/home' component={Home} />
                 <PrivateRoute path='/setting' component={Setting} />
                 <PrivateRoute path='/posts/new' component={PostForm} />
+                <PrivateRoute path='/posts/:id' component={PostDetail} />
                 <Route component={NotFound} />
               </Switch>
             </div>

--- a/frontend/src/components/Post.js
+++ b/frontend/src/components/Post.js
@@ -68,7 +68,7 @@ const Post = (props) => {
 
   return (
     <div className={classes.post}>
-      <Link className={classes.appName} href='/'>
+      <Link className={classes.appName} href={`/posts/${post.id}`}>
         {appName}
       </Link>
       <Typography className={classes.description}>

--- a/frontend/src/components/PostDetail.js
+++ b/frontend/src/components/PostDetail.js
@@ -43,15 +43,18 @@ const PostDetail = (props) => {
     icon: {
       borderRadius: '50%',
       height: 50,
+      margin: '0 auto',
       marginTop: 20,
       width: 50,
     },
     userName: {
-      marginLeft: 7,
+      overflowWrap: 'break-word',
     },
     postDetailLeft: {
       display: 'flex',
       flexDirection: 'column',
+      paddingRight: 5,
+      textAlign: 'center',
     },
     postDetailRight: {
       border: 'solid 1px #bbb',

--- a/frontend/src/components/PostDetail.js
+++ b/frontend/src/components/PostDetail.js
@@ -4,6 +4,7 @@ import DOMPurify from 'dompurify';
 import Grid from '@material-ui/core/Grid';
 import Button from '@material-ui/core/Button';
 import { makeStyles } from '@material-ui/core/styles';
+import logo from '../logo.svg';
 
 const PostDetail = (props) => {
   const { params } = props.match;
@@ -90,7 +91,7 @@ const PostDetail = (props) => {
       <Grid item xs={10} sm={10} md={6} lg={6}>
         <Grid container>
           <Grid item xs={12} lg={1} className={classes.postDetailLeft}>
-            <img src={userIconUrl} className={classes.icon} />
+            <img src={userIconUrl ? userIconUrl : logo} className={classes.icon} />
             <span className={classes.userName}>{userName}</span>
           </Grid>
           <Grid item xs={12} lg={11} className={classes.postDetailRight}>

--- a/frontend/src/components/PostDetail.js
+++ b/frontend/src/components/PostDetail.js
@@ -95,7 +95,10 @@ const PostDetail = (props) => {
       <Grid item xs={10} sm={10} md={6} lg={6}>
         <Grid container>
           <Grid item xs={12} lg={1} className={classes.postDetailLeft}>
-            <img src={userIconUrl ? userIconUrl : logo} className={classes.icon} />
+            <img
+              src={userIconUrl ? userIconUrl : logo}
+              className={classes.icon}
+            />
             <span className={classes.userName}>{userName}</span>
           </Grid>
           <Grid item xs={12} lg={11} className={classes.postDetailRight}>

--- a/frontend/src/components/PostDetail.js
+++ b/frontend/src/components/PostDetail.js
@@ -41,6 +41,7 @@ const PostDetail = (props) => {
       marginTop: 100,
     },
     icon: {
+      border: 'solid 1px #bbb',
       borderRadius: '50%',
       height: 50,
       margin: '0 auto',

--- a/frontend/src/components/PostDetail.js
+++ b/frontend/src/components/PostDetail.js
@@ -1,0 +1,134 @@
+import React, { useState, useEffect } from 'react';
+import marked from 'marked';
+import DOMPurify from 'dompurify';
+import Grid from '@material-ui/core/Grid';
+import Button from '@material-ui/core/Button';
+import { makeStyles } from '@material-ui/core/styles';
+
+const PostDetail = (props) => {
+  const { params } = props.match;
+  const id = parseInt(params.id, 10);
+  const [post, setPost] = useState({
+    app_name: '',
+    app_url: '',
+    repo_url: '',
+    description: '',
+    created_at: '',
+  });
+  const [userName, setUserName] = useState('');
+  const [userIconUrl, setUserIconUrl] = useState(null);
+
+  useEffect(() => {
+    fetch(`${process.env.REACT_APP_API_URL}/posts/${id}`, {
+      method: 'GET',
+      credentials: 'include',
+      headers: {
+        'X-Requested-With': 'XMLHttpRequest',
+      },
+    })
+      .then((res) => res.json())
+      .then((res) => {
+        setPost(res.post);
+        setUserName(res.user.name);
+        setUserIconUrl(res.user.icon.url);
+      });
+  }, []);
+
+  const styles = makeStyles({
+    postDetail: {
+      marginBottom: 20,
+      marginTop: 100,
+    },
+    icon: {
+      borderRadius: '50%',
+      height: 50,
+      marginTop: 20,
+      width: 50,
+    },
+    userName: {
+      marginLeft: 7,
+    },
+    postDetailLeft: {
+      display: 'flex',
+      flexDirection: 'column',
+    },
+    postDetailRight: {
+      border: 'solid 1px #bbb',
+      borderRadius: '10px',
+      padding: 20,
+    },
+    postDetailRightHeader: {
+      borderBottom: 'solid 1px #bbb',
+    },
+    appName: {
+      display: 'inline-block',
+      verticalAlign: 'middle',
+    },
+    link: {
+      color: '#fff',
+      display: 'inline-block',
+      margin: 10,
+      textDecoration: 'none',
+      verticalAlign: 'middle',
+    },
+    markdown: {
+      borderBottom: 'solid 1px #bbb',
+      overflowWrap: 'break-word',
+    },
+    postDetailFooter: {
+      display: 'flex',
+      justifyContent: 'flex-end',
+      marginTop: 10,
+    },
+  });
+
+  const classes = styles();
+
+  return (
+    <Grid container className={classes.postDetail}>
+      <Grid item xs={1} sm={1} md={3} lg={3} />
+      <Grid item xs={10} sm={10} md={6} lg={6}>
+        <Grid container>
+          <Grid item xs={12} lg={1} className={classes.postDetailLeft}>
+            <img src={userIconUrl} className={classes.icon} />
+            <span className={classes.userName}>{userName}</span>
+          </Grid>
+          <Grid item xs={12} lg={11} className={classes.postDetailRight}>
+            <div className={classes.postDetailRightHeader}>
+              <h1 className={classes.appName}>{post.app_name}</h1>
+              <a href={post.app_url} className={classes.link}>
+                <Button variant='contained' color='primary'>
+                  アプリ
+                </Button>
+              </a>
+              {post.repo_url && (
+                <a href={post.repo_url} className={classes.link}>
+                  <Button variant='contained' color='secondary'>
+                    レポジトリ
+                  </Button>
+                </a>
+              )}
+            </div>
+            <div
+              dangerouslySetInnerHTML={{
+                __html: DOMPurify.sanitize(marked(post.description)),
+              }}
+              className={classes.markdown}
+            ></div>
+            <div className={classes.postDetailFooter}>
+              {post.created_at && (
+                <span>
+                  {post.created_at.split('T')[0].substr(0, 10)}&nbsp;
+                  {post.created_at.split('T')[1].substr(0, 5)}に投稿
+                </span>
+              )}
+            </div>
+          </Grid>
+        </Grid>
+      </Grid>
+      <Grid item xs={1} sm={1} md={3} lg={3} />
+    </Grid>
+  );
+};
+
+export default PostDetail;

--- a/spec/requests/posts_spec.rb
+++ b/spec/requests/posts_spec.rb
@@ -33,10 +33,11 @@ RSpec.describe '/api/v1/posts', type: :request do
       log_in_as(user)
       get "/api/v1/posts/#{post.id}", headers: xhr_header
       expect(response.status).to eq(200)
-      expect(json(response)['app_name']).to eq(post.app_name)
-      expect(json(response)['app_url']).to eq(post.app_url)
-      expect(json(response)['repo_url']).to eq(post.repo_url)
-      expect(json(response)['description']).to eq(post.description)
+      expect(json(response)['post']['app_name']).to eq(post.app_name)
+      expect(json(response)['post']['app_url']).to eq(post.app_url)
+      expect(json(response)['post']['repo_url']).to eq(post.repo_url)
+      expect(json(response)['post']['description']).to eq(post.description)
+      expect(json(response)['user']['name']).to eq(user.name)
     end
 
     it 'reject an unauth user' do


### PR DESCRIPTION
### 関連issue
#61 

### やったこと
- GET `/posts/:id` で投稿と、その投稿をしたユーザーを返すように修正
- 投稿詳細ページを作成

### UI
<img width="800" alt="スクリーンショット 2021-11-04 20 44 55" src="https://user-images.githubusercontent.com/61813626/140308138-8febb5e2-4bf8-4c3f-b3d4-e7af3866e52f.png">

### 備考
- レスポンシブ対応ができていないので後で修正
- アプリURL、レポジトリURLは、先頭にhttp://, https:// をつけて保存しておかないと、リンクが正しく動作しない(アプリURLがexample.comだと、/posts/example.comに遷移してしまう)ので、後で修正

### 参考
- [Reactの外部リンクには、httpまたはhttpsが存在しない場合、localhostが追加されます](https://qapicks.com/question/63720487-654753902676)
- [CSS：縦中央揃えにする方法まとめ](https://yu-z.com/vertical-alignment/)
- [button要素にはhref属性を持つa要素を(本来は)含めてはいけない。](https://qiita.com/khsk/items/c026b4a21ac27b2cea71)
- [String.prototype.substr()](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/String/substr)
- [HTMLで空白を入れたい時に使う謎の文字＆nbsp; とは？](https://www.asoblock.net/contents/nbsp)
- [class vs className in React 16](https://stackoverflow.com/questions/46989454/class-vs-classname-in-react-16)
- [Reactでのレスポンシブ対応](https://www.ted027.com/post/react-mediaquery/)